### PR TITLE
MMA-1561. Extend auth ACL:

### DIFF
--- a/src/src/globals.c
+++ b/src/src/globals.c
@@ -460,6 +460,8 @@ uschar *acl_not_smtp_mime      = NULL;
 uschar *acl_not_smtp_start     = NULL;
 uschar *acl_removed_headers    = NULL;
 uschar *acl_smtp_auth          = NULL;
+uschar *acl_smtp_auth_accept   = NULL;
+uschar *acl_smtp_auth_fail     = NULL;
 uschar *acl_smtp_connect       = NULL;
 uschar *acl_smtp_data          = NULL;
 #ifndef DISABLE_PRDR

--- a/src/src/globals.h
+++ b/src/src/globals.h
@@ -293,6 +293,8 @@ extern uschar *acl_not_smtp_mime;      /* For MIME parts of ditto */
 extern uschar *acl_not_smtp_start;     /* ACL run at the beginning of a non-SMTP session */
 extern uschar *acl_removed_headers;    /* Headers deleted by an ACL */
 extern uschar *acl_smtp_auth;          /* ACL run for AUTH */
+extern uschar *acl_smtp_auth_accept;   /* ACL run for AUTH Success*/
+extern uschar *acl_smtp_auth_fail;     /* ACL run for AUTH Fail*/
 extern uschar *acl_smtp_connect;       /* ACL run on SMTP connection */
 extern uschar *acl_smtp_data;          /* ACL run after DATA received */
 #ifndef DISABLE_PRDR

--- a/src/src/readconf.c
+++ b/src/src/readconf.c
@@ -40,6 +40,8 @@ static optionlist optionlist_config[] = {
 #endif
   { "acl_not_smtp_start",       opt_stringptr,   &acl_not_smtp_start },
   { "acl_smtp_auth",            opt_stringptr,   &acl_smtp_auth },
+  { "acl_smtp_auth_accept",     opt_stringptr,   &acl_smtp_auth_accept },
+  { "acl_smtp_auth_fail",       opt_stringptr,   &acl_smtp_auth_fail },
   { "acl_smtp_connect",         opt_stringptr,   &acl_smtp_connect },
   { "acl_smtp_data",            opt_stringptr,   &acl_smtp_data },
 #ifndef DISABLE_PRDR

--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -3694,10 +3694,10 @@ smtp_respond(code, len, TRUE, user_msg);
 
 
 static int
-smtp_in_auth(auth_instance *au, uschar ** s, uschar ** ss)
+smtp_in_auth(auth_instance *au, uschar ** s, uschar ** ss, uschar *user_msg, uschar *log_msg)
 {
 const uschar *set_id = NULL;
-int rc, i;
+int rc, acl_rc, i;
 
 /* Run the checking code, passing the remainder of the command line as
 data. Initials the $auth<n> variables as empty. Initialize $0 empty and set
@@ -3728,6 +3728,18 @@ printing characters. */
 
 if (set_id) set_id = string_printing(set_id);
 
+if (set_id != NULL) strcpy(smtp_cmd_argument, set_id);
+/* Check the ACL */
+if (acl_smtp_auth != NULL)
+ {
+  acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth, &user_msg, &log_msg);
+  if (acl_rc != OK)
+  {
+    smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+    return acl_rc;
+  }
+ }
+
 /* For the non-OK cases, set up additional logging data if set_id
 is not empty. */
 
@@ -3742,6 +3754,16 @@ switch(rc)
   case OK:
   if (!au->set_id || set_id)    /* Complete success */
     {
+    if (acl_smtp_auth_accept != NULL)
+      {
+        acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_accept, &user_msg, &log_msg);
+        if (acl_rc != OK)
+        {
+          smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+          rc = acl_rc;
+          break;
+        }
+      }
     if (set_id) authenticated_id = string_copy_malloc(set_id);
     sender_host_authenticated = au->name;
     sender_host_auth_pubname  = au->public_name;
@@ -3783,6 +3805,15 @@ switch(rc)
   break;
 
   case FAIL:
+  if (acl_smtp_auth_fail != NULL)
+    {
+      acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_fail, &user_msg, &log_msg);
+      if (acl_rc != OK)
+      {
+        smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+        break;
+      }
+    }
   if (set_id) authenticated_fail_id = string_copy_malloc(set_id);
   *s = US"535 Incorrect authentication data";
   *ss = string_sprintf("535 Incorrect authentication data%s", set_id);
@@ -3971,11 +4002,12 @@ while (done <= 0)
 		      &user_msg, &log_msg)) != OK
 	   )
 	  done = smtp_handle_acl_fail(ACL_WHERE_AUTH, rc, user_msg, log_msg);
+
 	else
 	  {
 	  smtp_cmd_data = NULL;
 
-	  if (smtp_in_auth(au, &s, &ss) == OK)
+	  if (smtp_in_auth(au, &s, &ss, &user_msg, &log_msg) == OK)
 	    { DEBUG(D_auth) debug_printf("tls auth succeeded\n"); }
 	  else
 	    { DEBUG(D_auth) debug_printf("tls auth not succeeded\n"); }
@@ -4037,18 +4069,7 @@ while (done <= 0)
 	break;
 	}
 
-      /* Check the ACL */
-
-      if (  acl_smtp_auth
-	 && (rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth,
-		    &user_msg, &log_msg)) != OK
-	 )
-	{
-	done = smtp_handle_acl_fail(ACL_WHERE_AUTH, rc, user_msg, log_msg);
-	break;
-	}
-
-      /* Find the name of the requested authentication mechanism. */
+    /* Find the name of the requested authentication mechanism. */
 
       s = smtp_cmd_data;
       while ((c = *smtp_cmd_data) != 0 && !isspace(c))
@@ -4082,7 +4103,7 @@ while (done <= 0)
 
       if (au)
 	{
-	c = smtp_in_auth(au, &s, &ss);
+	c = smtp_in_auth(au, &s, &ss, &user_msg, &log_msg);
 
 	smtp_printf("%s\r\n", FALSE, s);
 	if (c != OK)


### PR DESCRIPTION
 - Run ACL `acl_smtp_auth` AFTER the AUTH is completed instead of before
 - Add new ACL `acl_smtp_auth_accept` runs on AUTH success
 - Add new ACL `acl_smtp_auth_fail` runs on AUTH failure