### PR TITLE
MMA-1562 Apply add events for temporary failures patch

### DIFF
--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -1692,7 +1692,17 @@ else if (result == DEFER || result == PANIC)
   /* If doing a 2-stage queue run, we skip writing to either the message
   log or the main log for SMTP defers. */
 
-  if (!f.queue_2stage || addr->basic_errno != 0)
+  if (!queue_2stage || addr->basic_errno != 0)
+#ifndef DISABLE_EVENT
+    /* Skip this event for errors of the type "retry time not reached" */
+    if (addr->basic_errno >= ERRNO_RETRY_BASE)
+    {
+      if (deliver_freeze)
+        msg_event_raise(US"msg:defer:delivery:frozen", addr);
+      else
+        msg_event_raise(US"msg:defer:delivery", addr);
+    }
+#endif
     deferral_log(addr, now, logflags, driver_name, driver_kind);
   }
 
@@ -7488,6 +7498,11 @@ while (addr_failed)
   DEBUG(D_deliver)
     debug_printf("processing failed address %s\n", addr_failed->address);
 
+#ifndef DISABLE_EVENT
+  for (addr = addr_failed; addr != NULL; addr = addr->next)
+    msg_event_raise(US"msg:fail:delivery:expired", addr);
+#endif
+
   /* There are only two ways an address in a bounce message can get here:
 
   (1) When delivery was initially deferred, but has now timed out (in the call
@@ -7973,6 +7988,9 @@ wording. */
         {
         for (addr = handled_addr; addr; addr = addr->next)
           {
+#ifndef DISABLE_EVENT
+          msg_event_raise(US"msg:fail:delivery:bounced", addr);
+#endif
           address_done(addr, logtod);
           child_done(addr, logtod);
           }


### PR DESCRIPTION
 - `msg:defer:delivery` event for temporary delivery errors
 - `msg:defer:delivery:frozen` event for temporary delivery errors that freeze the message
 - `msg:fail:delivery:expired` event delivery errors, removing the message from the queue
 - `msg:fail:delivery:bounced` event delivery errors that bounce the message from the queue