### PR TITLE
MMA-1572. Apply fix handling temporary rejenction at callout patch

### DIFF
--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -808,7 +808,7 @@ tls_retry_connection:
 	  case FAIL:		/* rejected: the preferred result */
 	    new_domain_record.random_result = ccache_reject;
 	    sx.avoid_option = 0;
-
+          case DEFER:
 	    /* Between each check, issue RSET, because some servers accept only
 	    one recipient after MAIL FROM:<>.
 	    XXX We don't care about that for postmaster_full.  Should we? */
@@ -838,8 +838,6 @@ tls_retry_connection:
 	    sx.send_rset = TRUE;
 	    sx.completed_addr = FALSE;
 	    goto tls_retry_connection;
-	  case DEFER:		/* 4xx response to random */
-	    break;		/* Just to be clear. ccache_unknown, !done. */
 	  }
 
       /* Re-setup for main verify, or for the error message when failing */

--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -807,8 +807,9 @@ tls_retry_connection:
 	    goto no_conn;
 	  case FAIL:		/* rejected: the preferred result */
 	    new_domain_record.random_result = ccache_reject;
+	  case DEFER:
 	    sx.avoid_option = 0;
-          case DEFER:
+
 	    /* Between each check, issue RSET, because some servers accept only
 	    one recipient after MAIL FROM:<>.
 	    XXX We don't care about that for postmaster_full.  Should we? */


### PR DESCRIPTION
Not sure if I should do:
	    sx.avoid_option = 0;
only on FAIL or include it also on DEFER.

Original patch was applied here:
https://github.com/SpamExperts/exim/commit/6bc3d4e9dc26a178cd09592e818c836cf83183db