### PR TITLE
MMA 2760 DMARC RUF reports appear to be broken

### DIFF
--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -163,12 +163,6 @@ FILE *message_file = NULL;
 if (!dmarc_enable_forensic)
   return;
 
-
-log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%d action=%d", dmarc_policy, action);
-log_write(0, LOG_MAIN, "POLICY - REJECT IS %d, QUARANTINE IS %d, NONE IS %d", DMARC_POLICY_REJECT, DMARC_POLICY_QUARANTINE, DMARC_POLICY_NONE);
-log_write(0, LOG_MAIN, "RESULT - REJECT IS %d, QUARANTINE IS %d", DMARC_RESULT_REJECT, DMARC_RESULT_QUARANTINE);
-
-
 if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    || dmarc_policy == DMARC_POLICY_QUARANTINE && action == DMARC_RESULT_QUARANTINE
    || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_REJECT
@@ -177,7 +171,6 @@ if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    )
   if (ruf)
     {
-    log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: success");
     eblock = add_to_eblock(eblock, US"Sender Domain", dmarc_used_domain);
     eblock = add_to_eblock(eblock, US"Sender IP Address", sender_host_address);
     eblock = add_to_eblock(eblock, US"Received Date", tod_stamp(tod_full));

--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -165,6 +165,8 @@ if (!dmarc_enable_forensic)
 
 
 log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%d action=%d", dmarc_policy, action);
+log_write(0, LOG_MAIN, "POLICY - REJECT IS %d, QUARANTINE IS %d, NONE IS %d", DMARC_POLICY_REJECT, DMARC_POLICY_QUARANTINE, DMARC_POLICY_NONE);
+log_write(0, LOG_MAIN, "RESULT - REJECT IS %d, QUARANTINE IS %d", DMARC_RESULT_REJECT, DMARC_RESULT_QUARANTINE);
 
 
 if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT

--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -163,6 +163,10 @@ FILE *message_file = NULL;
 if (!dmarc_enable_forensic)
   return;
 
+
+log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%s action=%s", dmarc_policy, action);
+
+
 if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    || dmarc_policy == DMARC_POLICY_QUARANTINE && action == DMARC_RESULT_QUARANTINE
    || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_REJECT
@@ -170,6 +174,7 @@ if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    )
   if (ruf)
     {
+    log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: success");
     eblock = add_to_eblock(eblock, US"Sender Domain", dmarc_used_domain);
     eblock = add_to_eblock(eblock, US"Sender IP Address", sender_host_address);
     eblock = add_to_eblock(eblock, US"Received Date", tod_stamp(tod_full));

--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -164,7 +164,7 @@ if (!dmarc_enable_forensic)
   return;
 
 
-//log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%s action=%s", dmarc_policy, action);
+log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%d action=%d", dmarc_policy, action);
 
 
 if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
@@ -174,7 +174,7 @@ if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    )
   if (ruf)
     {
-    //log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: success");
+    log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: success");
     eblock = add_to_eblock(eblock, US"Sender Domain", dmarc_used_domain);
     eblock = add_to_eblock(eblock, US"Sender IP Address", sender_host_address);
     eblock = add_to_eblock(eblock, US"Received Date", tod_stamp(tod_full));

--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -173,6 +173,7 @@ if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    || dmarc_policy == DMARC_POLICY_QUARANTINE && action == DMARC_RESULT_QUARANTINE
    || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_REJECT
    || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_QUARANTINE
+   || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_ACCEPT
    )
   if (ruf)
     {

--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -164,7 +164,7 @@ if (!dmarc_enable_forensic)
   return;
 
 
-log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%s action=%s", dmarc_policy, action);
+//log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: dmarc_policy=%s action=%s", dmarc_policy, action);
 
 
 if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
@@ -174,7 +174,7 @@ if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    )
   if (ruf)
     {
-    log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: success");
+    //log_write(0, LOG_MAIN, "DMARC SEND FORENSIC REPORT: success");
     eblock = add_to_eblock(eblock, US"Sender Domain", dmarc_used_domain);
     eblock = add_to_eblock(eblock, US"Sender IP Address", sender_host_address);
     eblock = add_to_eblock(eblock, US"Received Date", tod_stamp(tod_full));


### PR DESCRIPTION
Added another case in order to receive DMARC RUF reports when policy is 'none'.

Worth mentioning:
I modified based on the branch `exim-4_89+se+encr`.
Currently, the version installed on the testing servers is `se-exim_4.89+se-27`. The jenkins build for this PR is `se-exim_4.89+se-26`, so it needs a manual downgrade on the server in order to test.
Since it's just a line, perhaps it could be included in the next se-exim release.