### PR TITLE
MMA-4567 - Add Master API support to send secure emails

### DIFF
--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -631,6 +631,7 @@ FIXED_NEVER_USERS=root
 # By default, no macros are whitelisted for -D usage.
 
 # WHITELIST_D_MACROS=TLS:SPOOL
+WHITELIST_D_MACROS=AUTH_DOMAIN:AUTH_USERNAME
 
 #------------------------------------------------------------------------------
 # Exim has support for the AUTH (authentication) extension of the SMTP


### PR DESCRIPTION
Secure Emails are locally sent via Master API, which means their `auth_domain` and `auth_user` default to `seinternal.com` and `local`. Whitelist `AUTH_DOMAIN` and `AUTH_USERNAME` macros so that we can correctly send them from task.