### PR TITLE
MMA-8456 - Apply "Extend header add buffer size" patch

### DIFF
--- a/src/src/config.h.defaults
+++ b/src/src/config.h.defaults
@@ -77,7 +77,7 @@ Do not put spaces between # and the 'define'.
 #define HAVE_LOCAL_SCAN
 #define HAVE_SA_LEN
 #define HEADERS_CHARSET           "ISO-8859-1"
-#define HEADER_ADD_BUFFER_SIZE    (8192 * 4)
+#define HEADER_ADD_BUFFER_SIZE    (8192 * 10)
 #define HEADER_MAXSIZE            (1024*1024)
 
 #define INPUT_DIRECTORY_MODE       0750


### PR DESCRIPTION
### Why we need this
We need to apply our changes to the new exim version 4.94.2

### How we do it
Re-apply the change from https://github.com/SpamExperts/exim/commit/e85955d0150d2e4503650201a31e52ea9dc34c40