### PR TITLE
MMA-8499 - Apply security patches from Debian

### DIFF
--- a/src/src/auths/auth-spa.c
+++ b/src/src/auths/auth-spa.c
@@ -1252,15 +1252,10 @@ spa_bytes_add(ptr, header, b, len*2); \
 }
 
 
-#define GetUnicodeString(structPtr, header) \
-unicodeToString(((char*)structPtr) + IVAL(&structPtr->header.offset,0) , SVAL(&structPtr->header.len,0)/2)
-#define GetString(structPtr, header) \
-toString(((CS structPtr) + IVAL(&structPtr->header.offset,0)), SVAL(&structPtr->header.len,0))
-
 #ifdef notdef
 
 #define DumpBuffer(fp, structPtr, header) \
-dumpRaw(fp,(US structPtr)+IVAL(&structPtr->header.offset,0),SVAL(&structPtr->header.len,0))
+ dumpRaw(fp,(US structPtr)+IVAL(&structPtr->header.offset,0),SVAL(&structPtr->header.len,0))
 
 
 static void
@@ -1324,7 +1319,32 @@ buf[len] = 0;
 return buf;
 }
 
+static inline uschar *
+get_challenge_unistr(SPAAuthChallenge * challenge, SPAStrHeader * hdr)
+{
+int off = IVAL(&hdr->offset, 0);
+int len = SVAL(&hdr->len, 0);
+return off + len < sizeof(SPAAuthChallenge)
+  ? US unicodeToString(CS challenge + off, len/2) : US"";
+}
+
+static inline uschar *
+get_challenge_str(SPAAuthChallenge * challenge, SPAStrHeader * hdr)
+{
+int off = IVAL(&hdr->offset, 0);
+int len = SVAL(&hdr->len, 0);
+return off + len < sizeof(SPAAuthChallenge)
+  ? US toString(CS challenge + off, len) : US"";
+}
+
 #ifdef notdef
+
+#define GetUnicodeString(structPtr, header) \
+ unicodeToString(((char*)structPtr) + IVAL(&structPtr->header.offset,0) , SVAL(&structPtr->header.len,0)/2)
+
+#define GetString(structPtr, header) \
+ toString(((CS structPtr) + IVAL(&structPtr->header.offset,0)), SVAL(&structPtr->header.len,0))
+
 
 void
 dumpSmbNtlmAuthRequest (FILE * fp, SPAAuthRequest * request)
@@ -1497,8 +1517,8 @@ if (p)
   }
 
 else domain = d = string_copy(cf & 0x1
-  ? CUS GetUnicodeString(challenge, uDomain)
-  : CUS GetString(challenge, uDomain));
+  ? CUS get_challenge_unistr(challenge, &challenge->uDomain)
+  : CUS get_challenge_str(challenge, &challenge->uDomain));
 
 spa_smb_encrypt(password, challenge->challengeData, lmRespData);
 spa_smb_nt_encrypt(password, challenge->challengeData, ntRespData);

--- a/src/src/auths/auth-spa.c
+++ b/src/src/auths/auth-spa.c
@@ -1212,7 +1212,9 @@ char versionString[] = "libntlm version 0.21";
 
 #define spa_bytes_add(ptr, header, buf, count) \
 { \
-if (buf && (count) != 0) /* we hate -Wint-in-bool-contex */ \
+if (  buf && (count) != 0	/* we hate -Wint-in-bool-contex */ \
+   && ptr->bufIndex + count < sizeof(ptr->buffer)		\
+   ) \
   { \
   SSVAL(&ptr->header.len,0,count); \
   SSVAL(&ptr->header.maxlen,0,count); \

--- a/src/src/auths/auth-spa.c
+++ b/src/src/auths/auth-spa.c
@@ -153,6 +153,9 @@ int main (int argc, char ** argv)
    up with a different answer to the one above)
 */
 
+#ifndef MACRO_PREDEF
+
+
 #define DEBUG_X(a,b) ;
 
 extern int DEBUGLEVEL;
@@ -1227,21 +1230,21 @@ else \
 
 #define spa_string_add(ptr, header, string) \
 { \
-char *p = string; \
+uschar * p = string; \
 int len = 0; \
-if (p) len = strlen(p); \
-spa_bytes_add(ptr, header, (US p), len); \
+if (p) len = Ustrlen(p); \
+spa_bytes_add(ptr, header, p, len); \
 }
 
 #define spa_unicode_add_string(ptr, header, string) \
 { \
-char *p = string; \
-uschar *b = NULL; \
+uschar * p = string; \
+uschar * b = NULL; \
 int len = 0; \
 if (p) \
   { \
-  len = strlen(p); \
-  b = strToUnicode(p); \
+  len = Ustrlen(p); \
+  b = US strToUnicode(CS p); \
   } \
 spa_bytes_add(ptr, header, b, len*2); \
 }
@@ -1364,15 +1367,15 @@ fprintf (fp, "      Flags = %08x\n", IVAL (&response->flags, 0));
 #endif
 
 void
-spa_build_auth_request (SPAAuthRequest * request, char *user, char *domain)
+spa_build_auth_request (SPAAuthRequest * request, uschar * user, uschar * domain)
 {
-char *u = strdup (user);
-char *p = strchr (u, '@');
+uschar * u = string_copy(user);
+uschar * p = Ustrchr(u, '@');
 
 if (p)
   {
   if (!domain)
-   domain = p + 1;
+    domain = p + 1;
   *p = '\0';
   }
 
@@ -1382,7 +1385,6 @@ SIVAL (&request->msgType, 0, 1);
 SIVAL (&request->flags, 0, 0x0000b207);      /* have to figure out what these mean */
 spa_string_add (request, user, u);
 spa_string_add (request, domain, domain);
-free (u);
 }
 
 
@@ -1475,16 +1477,16 @@ free (u);
 
 void
 spa_build_auth_response (SPAAuthChallenge * challenge,
-                        SPAAuthResponse * response, char *user,
-                        char *password)
+                        SPAAuthResponse * response, uschar * user,
+                        uschar * password)
 {
 uint8x lmRespData[24];
 uint8x ntRespData[24];
 uint32x cf = IVAL(&challenge->flags, 0);
-char *u = strdup (user);
-char *p = strchr (u, '@');
-char *d = NULL;
-char *domain;
+uschar * u = string_copy(user);
+uschar * p = Ustrchr(u, '@');
+uschar * d = NULL;
+uschar * domain;
 
 if (p)
   {
@@ -1492,33 +1494,33 @@ if (p)
   *p = '\0';
   }
 
-else domain = d = strdup((cf & 0x1)?
-  CCS GetUnicodeString(challenge, uDomain) :
-  CCS GetString(challenge, uDomain));
+else domain = d = string_copy(cf & 0x1
+  ? CUS GetUnicodeString(challenge, uDomain)
+  : CUS GetString(challenge, uDomain));
 
-spa_smb_encrypt (US password, challenge->challengeData, lmRespData);
-spa_smb_nt_encrypt (US password, challenge->challengeData, ntRespData);
+spa_smb_encrypt(password, challenge->challengeData, lmRespData);
+spa_smb_nt_encrypt(password, challenge->challengeData, ntRespData);
 
 response->bufIndex = 0;
 memcpy (response->ident, "NTLMSSP\0\0\0", 8);
 SIVAL (&response->msgType, 0, 3);
 
-spa_bytes_add (response, lmResponse, lmRespData, (cf & 0x200) ? 24 : 0);
-spa_bytes_add (response, ntResponse, ntRespData, (cf & 0x8000) ? 24 : 0);
+spa_bytes_add(response, lmResponse, lmRespData, cf & 0x200 ? 24 : 0);
+spa_bytes_add(response, ntResponse, ntRespData, cf & 0x8000 ? 24 : 0);
 
 if (cf & 0x1) {      /* Unicode Text */
-     spa_unicode_add_string (response, uDomain, domain);
-     spa_unicode_add_string (response, uUser, u);
-     spa_unicode_add_string (response, uWks, u);
+     spa_unicode_add_string(response, uDomain, domain);
+     spa_unicode_add_string(response, uUser, u);
+     spa_unicode_add_string(response, uWks, u);
 } else {             /* OEM Text */
-     spa_string_add (response, uDomain, domain);
-     spa_string_add (response, uUser, u);
-     spa_string_add (response, uWks, u);
+     spa_string_add(response, uDomain, domain);
+     spa_string_add(response, uUser, u);
+     spa_string_add(response, uWks, u);
 }
 
-spa_string_add (response, sessionKey, NULL);
+spa_string_add(response, sessionKey, NULL);
 response->flags = challenge->flags;
-
-if (d != NULL) free (d);
-free (u);
 }
+
+
+#endif   /*!MACRO_PREDEF*/

--- a/src/src/auths/auth-spa.h
+++ b/src/src/auths/auth-spa.h
@@ -79,10 +79,10 @@ typedef struct
 
 void spa_bits_to_base64 (unsigned char *, const unsigned char *, int);
 int spa_base64_to_bits(char *, int, const char *);
-void spa_build_auth_response (SPAAuthChallenge *challenge,
-       SPAAuthResponse *response, char *user, char *password);
-void spa_build_auth_request (SPAAuthRequest *request, char *user,
-       char *domain);
+void spa_build_auth_response (SPAAuthChallenge * challenge,
+       SPAAuthResponse * response, uschar * user, uschar * password);
+void spa_build_auth_request (SPAAuthRequest * request, uschar * user,
+       uschar * domain);
 extern void spa_smb_encrypt (unsigned char * passwd, unsigned char * c8,
                              unsigned char * p24);
 extern void spa_smb_nt_encrypt (unsigned char * passwd, unsigned char * c8,

--- a/src/src/auths/external.c
+++ b/src/src/auths/external.c
@@ -103,7 +103,7 @@ if (expand_nmax == 0) 	/* skip if rxd data */
 if (ob->server_param2)
   {
   uschar * s = expand_string(ob->server_param2);
-  auth_vars[expand_nmax] = s;
+  auth_vars[expand_nmax = 1] = s;
   expand_nstring[++expand_nmax] = s;
   expand_nlength[expand_nmax] = Ustrlen(s);
   if (ob->server_param3)

--- a/src/src/auths/spa.c
+++ b/src/src/auths/spa.c
@@ -284,14 +284,13 @@ SPAAuthRequest   request;
 SPAAuthChallenge challenge;
 SPAAuthResponse  response;
 char msgbuf[2048];
-char *domain = NULL;
-char *username, *password;
+uschar * domain = NULL, * username, * password;
 
 /* Code added by PH to expand the options */
 
 *buffer = 0;    /* Default no message when cancelled */
 
-if (!(username = CS expand_string(ob->spa_username)))
+if (!(username = expand_string(ob->spa_username)))
   {
   if (f.expand_string_forcedfail) return CANCELLED;
   string_format(buffer, buffsize, "expansion of \"%s\" failed in %s "
@@ -300,7 +299,7 @@ if (!(username = CS expand_string(ob->spa_username)))
   return ERROR;
   }
 
-if (!(password = CS expand_string(ob->spa_password)))
+if (!(password = expand_string(ob->spa_password)))
   {
   if (f.expand_string_forcedfail) return CANCELLED;
   string_format(buffer, buffsize, "expansion of \"%s\" failed in %s "
@@ -310,7 +309,7 @@ if (!(password = CS expand_string(ob->spa_password)))
   }
 
 if (ob->spa_domain)
-  if (!(domain = CS expand_string(ob->spa_domain)))
+  if (!(domain = expand_string(ob->spa_domain)))
     {
     if (f.expand_string_forcedfail) return CANCELLED;
     string_format(buffer, buffsize, "expansion of \"%s\" failed in %s "
@@ -330,7 +329,7 @@ if (!smtp_read_response(sx, US buffer, buffsize, '3', timeout))
 
 DSPA("\n\n%s authenticator: using domain %s\n\n", ablock->name, domain);
 
-spa_build_auth_request(&request, CS username, domain);
+spa_build_auth_request(&request, username, domain);
 spa_bits_to_base64(US msgbuf, US &request, spa_request_length(&request));
 
 DSPA("\n\n%s authenticator: sending request (%s)\n\n", ablock->name, msgbuf);
@@ -347,7 +346,7 @@ if (!smtp_read_response(sx, US buffer, buffsize, '3', timeout))
 DSPA("\n\n%s authenticator: challenge (%s)\n\n", ablock->name, buffer + 4);
 spa_base64_to_bits(CS (&challenge), sizeof(challenge), CCS (buffer + 4));
 
-spa_build_auth_response(&challenge, &response, CS username, CS password);
+spa_build_auth_response(&challenge, &response, username, password);
 spa_bits_to_base64(US msgbuf, US &response, spa_request_length(&response));
 DSPA("\n\n%s authenticator: challenge response (%s)\n\n", ablock->name, msgbuf);
 


### PR DESCRIPTION
### Why we need this
We need to apply security patches to our Exim 4.94

### How we fix it
Apply the following patches from the Debian distribution of Exim:
https://sources.debian.org/patches/exim4/4.94.2-7%2Bdeb11u1/75_29-Auths-fix-possible-OOB-write-in-external-authenticat.patch/
https://sources.debian.org/patches/exim4/4.94.2-7%2Bdeb11u1/75_31-Auths-fix-possible-OOB-write-in-SPA-authenticator.-B.patch/
https://sources.debian.org/patches/exim4/4.94.2-7%2Bdeb11u1/75_30-Auths-use-uschar-more-in-spa-authenticator.patch/
https://sources.debian.org/patches/exim4/4.94.2-7%2Bdeb11u1/75_32-Auths-fix-possible-OOB-read-in-SPA-authenticator.-Bu.patch/