### PR TITLE
MMA-8449 - Apply Extend auth ACLs patch

### DIFF
--- a/src/src/globals.c
+++ b/src/src/globals.c
@@ -441,6 +441,8 @@ uschar *acl_not_smtp_mime      = NULL;
 uschar *acl_not_smtp_start     = NULL;
 uschar *acl_removed_headers    = NULL;
 uschar *acl_smtp_auth          = NULL;
+uschar *acl_smtp_auth_accept   = NULL;
+uschar *acl_smtp_auth_fail     = NULL;
 uschar *acl_smtp_connect       = NULL;
 uschar *acl_smtp_data          = NULL;
 #ifndef DISABLE_PRDR

--- a/src/src/globals.h
+++ b/src/src/globals.h
@@ -307,6 +307,8 @@ extern uschar *acl_not_smtp_mime;      /* For MIME parts of ditto */
 extern uschar *acl_not_smtp_start;     /* ACL run at the beginning of a non-SMTP session */
 extern uschar *acl_removed_headers;    /* Headers deleted by an ACL */
 extern uschar *acl_smtp_auth;          /* ACL run for AUTH */
+extern uschar *acl_smtp_auth_accept;   /* ACL run for AUTH Success*/
+extern uschar *acl_smtp_auth_fail;     /* ACL run for AUTH Fail*/
 extern uschar *acl_smtp_connect;       /* ACL run on SMTP connection */
 extern uschar *acl_smtp_data;          /* ACL run after DATA received */
 #ifndef DISABLE_PRDR

--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -3774,7 +3774,7 @@ smtp_respond(code, len, TRUE, user_msg);
 
 
 static int
-smtp_in_auth(auth_instance *au, uschar ** s, uschar ** ss)
+smtp_in_auth(auth_instance *au, uschar ** s, uschar ** ss, uschar *user_msg, uschar *log_msg)
 {
 const uschar *set_id = NULL;
 int rc;
@@ -3807,6 +3807,18 @@ can (did) happen. To guard against this, ensure that the id contains only
 printing characters. */
 
 if (set_id) set_id = string_printing(set_id);
+
+if (set_id != NULL) strcpy(smtp_cmd_argument, set_id);
+/* Check the ACL */
+if (acl_smtp_auth != NULL)
+ {
+  acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth, &user_msg, &log_msg);
+  if (acl_rc != OK)
+  {
+    smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+    return acl_rc;
+  }
+ }
 
 /* For the non-OK cases, set up additional logging data if set_id
 is not empty. */


### PR DESCRIPTION
### Why we need this

We need to apply our changes to the new Exim version.

### How we fix it

Apply changes from https://github.com/SpamExperts/exim/commit/23614f8d4c0fdea0ec3d293c0c9e78dba5b56837 to the new  version.

- Run ACL `acl_smtp_auth` AFTER the AUTH is completed instead of before
 - Add new ACL `acl_smtp_auth_accept` runs on AUTH success
 - Add new ACL `acl_smtp_auth_fail` runs on AUTH failure