### PR TITLE
Add Diagnostic-Code for unroutable address

### DIFF
--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -7833,7 +7833,7 @@ wording. */
           addr->next = handled_addr;
           handled_addr = topaddr;
           }
-          print_dsn_diagnostic_code(addr, f);
+          print_dsn_diagnostic_code(addr, fp);
 	fputc('\n', fp);
         }
 

--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -5393,15 +5393,27 @@ Returns:       nothing
 static void
 print_dsn_diagnostic_code(const address_item *addr, FILE *f)
 {
-uschar * s = testflag(addr, af_pass_message) ? addr->message : NULL;
+uschar * s;
 unsigned cnt;
+DEBUG(D_deliver)
+  debug_printf("DSN Diagnostic-Code: pass_message=%s, message=%s, user_message=%s\n", testflag(addr, af_pass_message), addr->message, addr->user_message);
 
 /* af_pass_message and addr->message set ? print remote host answer */
-if (s)
+/* search first ": ". we assume to find the remote-MTA answer there */
+if (testflag(addr, af_pass_message) && addr->message && Ustrstr(addr->message, ": "))
   {
-  DEBUG(D_deliver)
-    debug_printf("DSN Diagnostic-Code: addr->message = %s\n", addr->message);
-
+  s = addr->message;
+  s = Ustrstr(addr->message, ": ");
+  s += 2;
+  }
+else
+  {
+  s = addr->user_message;
+  }
+DEBUG(D_deliver)
+  debug_printf("DSN Diagnostic-Code: %s\n", s);
+  if (s)
+  {
   /* search first ": ". we assume to find the remote-MTA answer there */
   if (!(s = Ustrstr(addr->message, ": ")))
     return;				/* not found, bail out */
@@ -7821,6 +7833,7 @@ wording. */
           addr->next = handled_addr;
           handled_addr = topaddr;
           }
+          print_dsn_diagnostic_code(addr, f);
 	fputc('\n', fp);
         }
 


### PR DESCRIPTION
### Why we need this
We need to apply our patches and changes to exim 4.94

### How we fix it
Apply https://github.com/SpamExperts/exim/commit/3da1e173b860eb84aa240022ebbfb0c6410a443e#diff-c912af8a2087864ecc79401b0070e4b1ca2f889afdb93c08eacfeadd86b8276cR5315 to the `exim-4.94+fixes+se+encr` branch.

This was done manually, as there were some merge conflicts when trying to cherry pick the commit, and it looked simpler to just ensure the changes are applied.