### PR TITLE
MMA-8463 - Enable missing options 

### DIFF
--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -1028,9 +1028,9 @@ SUPPORT_PROXY=yes
 # need libidn2 and SUPPORT_I18N_2008.
 
 SUPPORT_I18N=yes
-# LDFLAGS += -lidn
-# SUPPORT_I18N_2008=yes
-# LDFLAGS += -lidn -lidn2
+LDFLAGS += -lidn
+SUPPORT_I18N_2008=yes
+LDFLAGS += -lidn -lidn2
 
 
 #------------------------------------------------------------------------------

--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -1014,7 +1014,7 @@ SUPPORT_SOCKS=yes
 # If you may want to use inbound (server-side) proxying, using Proxy Protocol,
 # uncomment the line below.
 
-# SUPPORT_PROXY=yes
+SUPPORT_PROXY=yes
 
 
 #------------------------------------------------------------------------------

--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -1027,7 +1027,7 @@ SUPPORT_PROXY=yes
 # If you want IDNA2008 mappings per RFCs 5890, 6530 and 6533, you additionally
 # need libidn2 and SUPPORT_I18N_2008.
 
-# SUPPORT_I18N=yes
+SUPPORT_I18N=yes
 # LDFLAGS += -lidn
 # SUPPORT_I18N_2008=yes
 # LDFLAGS += -lidn -lidn2


### PR DESCRIPTION
### Why we need this

While working on mentioned ticket, we discovered that some of the options were not enabled (`SUPPORT_PROXY`, `SUPPORT_I18N`, `LDFLAGS`, `SUPPORT_I18N_2008`) and prevented Exim from being properly installed.

### Tickets/Links

MMA-8463

### How we fix it

Enable missing options.