### PR TITLE
MMA-8740 - Apply bug fix for Exim DMARC issue with wrong dmarc_domain identified for some messages

### DIFF
--- a/src/src/receive.c
+++ b/src/src/receive.c
@@ -1622,6 +1622,7 @@ BOOL date_header_exists = FALSE;
 /* Pointers to receive the addresses of headers whose contents we need. */
 
 header_line *from_header = NULL;
+header_line *from_header_for_dmarc = NULL;
 header_line *subject_header = NULL;
 header_line *msgid_header = NULL;
 header_line *received_header;
@@ -2250,6 +2251,10 @@ for (h = header_list->next; h; h = h->next)
 
     case htype_from:
     h->type = htype_from;
+    if (!is_resent && !from_header_for_dmarc)
+    {
+      from_header_for_dmarc = h;
+    }
     if (!resents_exist || is_resent)
       {
       from_header = h;
@@ -3448,7 +3453,7 @@ else
 #endif /* WITH_CONTENT_SCAN */
 
 #ifdef EXPERIMENTAL_DMARC
-    dmarc_up = dmarc_store_data(from_header);
+    dmarc_up = dmarc_store_data(from_header_for_dmarc);
 #endif /* EXPERIMENTAL_DMARC */
 
 #ifndef DISABLE_PRDR
@@ -4020,7 +4025,7 @@ if (message_logs && blackholed_by == NULL)
   int fd;
 
   spool_name = spool_fname(US"msglog", message_subdir, message_id, US"");
-  
+
   if (  (fd = Uopen(spool_name, O_WRONLY|O_APPEND|O_CREAT, SPOOL_MODE)) < 0
      && errno == ENOENT
      )
@@ -4181,7 +4186,7 @@ if(!smtp_reply)
   if (deliver_freeze) log_write(0, LOG_MAIN, "frozen by %s", frozen_by);
   if (queue_only_policy) log_write(L_delay_delivery, LOG_MAIN,
     "no immediate delivery: queued%s%s by %s",
-    *queue_name ? " in " : "", *queue_name ? CS queue_name : "",       
+    *queue_name ? " in " : "", *queue_name ? CS queue_name : "",
     queued_by);
   }
 receive_call_bombout = FALSE;


### PR DESCRIPTION
### Why we need this

Coming from https://my.spamexperts.com/admin/supporttickets.php?action=view&id=395632 - customer issue:

We have a customer that reporting that a lot of external domain users are being rejected (showing bounced on their end).
In the logs I see the dmarc rejected but I cant find the first time it happened to check the reason, it worked for them for years and started to bounce in Sep 2023.

### Ticket

[MMA-8740](https://n-able.atlassian.net/browse/MMA-8740)

### How we fix it

Apply the changes from [here](https://bugs.exim.org/show_bug.cgi?id=3029).

[MMA-8740]: https://n-able.atlassian.net/browse/MMA-8740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ