### PR TITLE
MMA-8740 - Apply bug fix for Exim DMARC issue with wrong dmarc_domain identified for some messages

### DIFF
--- a/src/src/receive.c
+++ b/src/src/receive.c
@@ -1681,6 +1681,7 @@ BOOL date_header_exists = FALSE;
 /* Pointers to receive the addresses of headers whose contents we need. */
 
 header_line *from_header = NULL;
+header_line *from_header_for_dmarc = NULL;
 header_line *subject_header = NULL;
 header_line *msgid_header = NULL;
 header_line *received_header;
@@ -2309,6 +2310,10 @@ for (h = header_list->next; h; h = h->next)
 
     case htype_from:
       h->type = htype_from;
+      if (!is_resent && !from_header_for_dmarc)
+      {
+        from_header_for_dmarc = h;
+      }
       if (!resents_exist || is_resent)
 	{
 	from_header = h;
@@ -3470,7 +3475,7 @@ else
 #endif /* WITH_CONTENT_SCAN */
 
 #ifdef EXPERIMENTAL_DMARC
-    dmarc_up = dmarc_store_data(from_header);
+    dmarc_up = dmarc_store_data(from_header_for_dmarc);
 #endif /* EXPERIMENTAL_DMARC */
 
 #ifndef DISABLE_PRDR


### PR DESCRIPTION
### Why we need this

Coming from https://my.spamexperts.com/admin/supporttickets.php?action=view&id=395632 - customer issue:

We have a customer that reporting that a lot of external domain users are being rejected (showing bounced on their end).
In the logs I see the dmarc rejected but I cant find the first time it happened to check the reason, it worked for them for years and started to bounce in Sep 2023.

### Ticket

[MMA-8740](https://n-able.atlassian.net/browse/MMA-8740)

### How we fix it

Apply the changes from [here](https://bugs.exim.org/show_bug.cgi?id=3029).

[MMA-8740]: https://n-able.atlassian.net/browse/MMA-8740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ