### PR TITLE
MMA-9122 - Exim 4.94.2 is missing internal patches and features enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ exim-*
 *.orig
 *.rej
 .gdb_history
+.idea

--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -747,7 +747,7 @@ TRUSTED_CONFIG_LIST=/var/lib/exim4/trusted_configs
 #
 # By default, no macros are whitelisted for -D usage.
 
-# WHITELIST_D_MACROS=TLS:SPOOL
+WHITELIST_D_MACROS=RELEASE_MESSAGE:AUTH_USERNAME:AUTH_DOMAIN
 
 #------------------------------------------------------------------------------
 # Exim has support for the AUTH (authentication) extension of the SMTP

--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -4069,6 +4069,9 @@ if (acl_smtp_auth != NULL)
   if (acl_rc != OK)
   {
     smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+    if (set_id) authenticated_fail_id = string_copy_malloc(set_id);
+    *s = US"535 Incorrect authentication data";
+    *ss = string_sprintf("535 Incorrect authentication data%s", set_id);
     return acl_rc;
   }
  }
@@ -4087,6 +4090,18 @@ switch(rc)
   case OK:
     if (!au->set_id || set_id)    /* Complete success */
       {
+        if (set_id) authenticated_id = string_copy_malloc(set_id);
+        sender_host_authenticated = au->name;
+        sender_host_auth_pubname  = au->public_name;
+        authentication_failed = FALSE;
+        authenticated_fail_id = NULL;   /* Impossible to already be set? */
+
+        received_protocol =
+            (sender_host_address ? protocols : protocols_local)
+              [pextend + pauthed + (tls_in.active.sock >= 0 ? pcrpted:0)];
+        *s = *ss = US"235 Authentication succeeded";
+        authenticated_by = au;
+
       if (acl_smtp_auth_accept != NULL)
       {
         acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_accept, &user_msg, &log_msg);
@@ -4097,17 +4112,6 @@ switch(rc)
           break;
         }
       }
-      if (set_id) authenticated_id = string_copy_perm(set_id, TRUE);
-      sender_host_authenticated = au->name;
-      sender_host_auth_pubname  = au->public_name;
-      authentication_failed = FALSE;
-      authenticated_fail_id = NULL;   /* Impossible to already be set? */
-
-      received_protocol =
-	(sender_host_address ? protocols : protocols_local)
-	  [pextend + pauthed + (tls_in.active.sock >= 0 ? pcrpted:0)];
-      *s = *ss = US"235 Authentication succeeded";
-      authenticated_by = au;
       break;
       }
 
@@ -4118,7 +4122,7 @@ switch(rc)
     /* Fall through */
 
   case DEFER:
-    if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
+    if (set_id) authenticated_fail_id = string_copy_malloc(set_id);
     *s = string_sprintf("435 Unable to authenticate at present%s",
       auth_defer_user_msg);
     *ss = string_sprintf("435 Unable to authenticate at present%s: %s",
@@ -4138,7 +4142,11 @@ switch(rc)
     break;
 
   case FAIL:
-  if (acl_smtp_auth_fail != NULL)
+    if (set_id) authenticated_fail_id = string_copy_malloc(set_id);
+    *s = US"535 Incorrect authentication data";
+    *ss = string_sprintf("535 Incorrect authentication data%s", set_id);
+
+    if (acl_smtp_auth_fail != NULL)
     {
       acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_fail, &user_msg, &log_msg);
       if (acl_rc != OK)
@@ -4147,13 +4155,10 @@ switch(rc)
         break;
       }
     }
-    if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
-    *s = US"535 Incorrect authentication data";
-    *ss = string_sprintf("535 Incorrect authentication data%s", set_id);
     break;
 
   default:
-    if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
+    if (set_id) authenticated_fail_id = string_copy_malloc(set_id);
     *s = US"435 Internal error";
     *ss = string_sprintf("435 Internal error%s: return %d from authentication "
       "check", set_id, rc);

--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -741,7 +741,6 @@ tls_retry_connection:
       goto no_conn;
       }
 
-
     /* If we needed to authenticate, smtp_setup_conn() did that.  Copy
     the AUTH info for logging */
 

--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -741,8 +741,6 @@ tls_retry_connection:
       goto no_conn;
       }
 
-    /* We cannot use SIZE in MAIL FROM in a callout. */
-    sx->peer_offered &= ~OPTION_SIZE;
 
     /* If we needed to authenticate, smtp_setup_conn() did that.  Copy
     the AUTH info for logging */

--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -741,6 +741,9 @@ tls_retry_connection:
       goto no_conn;
       }
 
+    /* We cannot use SIZE in MAIL FROM in a callout. */
+    sx.peer_offered &= ~OPTION_SIZE;
+
     /* If we needed to authenticate, smtp_setup_conn() did that.  Copy
     the AUTH info for logging */
 

--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -742,7 +742,7 @@ tls_retry_connection:
       }
 
     /* We cannot use SIZE in MAIL FROM in a callout. */
-    sx.peer_offered &= ~OPTION_SIZE;
+    sx->peer_offered &= ~OPTION_SIZE;
 
     /* If we needed to authenticate, smtp_setup_conn() did that.  Copy
     the AUTH info for logging */


### PR DESCRIPTION
### Why we need this

Exim 4.94.2 is missing internal patches and features enabled. 

### Ticket

[MMA-9122](https://n-able.atlassian.net/browse/MMA-9122)

### How we fix it

After the last round of patches applied to `exim4.94.2`, it was noticed that some were missed. How he handled this is that we looked over all the patches applied to both `exim4.92` and `exim4.94` and tried to find the ones that are missing. We ended up with the following patches (which are applied in this PR):

- enable `WHITELIST_D_MACROS`: https://github.com/SpamExperts/exim/commit/7038eb39aa8f5882adae2c0ebd8274dd24a8c641
- Fix log message: https://github.com/SpamExperts/exim/commit/efa57784ef6a70138a3c447d0b4569ff7e34416b

[MMA-9122]: https://n-able.atlassian.net/browse/MMA-9122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ