### PR TITLE
MMA-9122 - Exim 4.94.2 is missing internal patches and features enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ exim-*
 *.orig
 *.rej
 .gdb_history
+.idea

--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -747,7 +747,7 @@ TRUSTED_CONFIG_LIST=/var/lib/exim4/trusted_configs
 #
 # By default, no macros are whitelisted for -D usage.
 
-# WHITELIST_D_MACROS=TLS:SPOOL
+WHITELIST_D_MACROS=RELEASE_MESSAGE:AUTH_USERNAME:AUTH_DOMAIN
 
 #------------------------------------------------------------------------------
 # Exim has support for the AUTH (authentication) extension of the SMTP


### PR DESCRIPTION
### Why we need this

Exim 4.94.2 is missing internal patches and features enabled. 

### Ticket

[MMA-9122](https://n-able.atlassian.net/browse/MMA-9122)

### How we fix it

After the last round of patches applied to `exim4.94.2`, it was noticed that some were missed. How he handled this is that we looked over all the patches applied to both `exim4.92` and `exim4.94` and tried to find the ones that are missing. In this PR, we are applying the following:

- enable `WHITELIST_D_MACROS`: https://github.com/SpamExperts/exim/commit/7038eb39aa8f5882adae2c0ebd8274dd24a8c641

[MMA-9122]: https://n-able.atlassian.net/browse/MMA-9122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ