### PR TITLE
MMA-1432 - Use Python 3 for local_scan

### DIFF
--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -1494,10 +1494,3 @@ MAX_NAMED_LIST=32
 # CFLAGS += -DMEASURE_TIMING
 
 # End of EDITME for Exim 4.
-
-CFLAGS+=-fPIC
-INCLUDE+=-I/usr/local/include/python2.7
-EXTRALIBS+=/usr/local/lib/python2.7/config/libpython2.7.a -lz -lm -lpthread -ldl  -lutil -Xlinker -export-dynamic -Wl,-O1 -Wl,-Bsymbolic-functions
-LOCAL_SCAN_SOURCE=Local/expy_local_scan.c
-LOCAL_SCAN_HAS_OPTIONS=yes
-HAVE_LOCAL_SCAN=yes


### PR DESCRIPTION
### Why we need this

We need to make exim work with both Python 2 and Python 3 interpreter so we can convert local_scan.py

### Tickets/Links

MMA-1432

### How we fix it

Remove compilation settings for `local_scan.o` and let [patch_exim_makefile.py](https://github.com/SpamExperts/py-exim-localscan/blob/master/patch_exim_makefile.py) handle them. This way we can embed either a Python 2 or a Python 3 interpreter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes SMTP/TLS stack (OCSP, session tickets, PIPE_CONNECT, DANE), hardens transports and taint handling, updates build/tests, and improves reliability across the codebase.
> 
> - **SMTP/TLS core**:
>   - Upgrade OpenSSL handling (1.1.1/3.0 compat), keylog, cipher stdnames, channel binding, Extended Master Secret.
>   - Add/expand features: OCSP stapling (multi-leaf, PEM/DER, caching), TLS session tickets/resumption, PIPE_CONNECT early pipelining, DANE refinements, PRDR handling, STARTTLS/error paths, SNI expansion.
>   - Robust error/timeouts; improved banner/EHLO sync; continued-connection/verify flow; size/auth/SIZE/UTF8 flags; DSN bits.
> - **Transports**:
>   - Appendfile/maildir/mailstore MBX fixes; taint-safe path handling (`bless`/`string_copy_taint`), safer writes/flush, quota and ocsp helpers.
>   - Pipe/autoreply refinements (arg/env handling, logging), queuefile transport added.
> - **Build/Configure**:
>   - Autoconf: detect any TLS client (`client-anytls`), OpenSSL/GnuTLS checks, getaddrinfo; Solaris/SunOS support tweaks.
> - **Tests**:
>   - Widespread suite updates (TLS/OCSP artifacts, policy JSON, harness env, scripts), new fixtures and adjusted configs to taint-safe vars.
> - **Misc**:
>   - Numerous refactors/cleanups (headers, trees, utf8, version, utils), safety and portability improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b2df49b83037a291998ecba10bbf4605e3b06ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->