### PR TITLE
MMA-10643. set proxy session true even on cancelled operations

### DIFF
--- a/src/src/transports/smtp_socks.c
+++ b/src/src/transports/smtp_socks.c
@@ -302,6 +302,7 @@ for(;;)
     {
     proxy_local_address = string_copy(proxy.address);
     proxy_local_port = sob->port;
+    proxy_session = TRUE;
     break;
     }
 


### PR DESCRIPTION
### Why

When connection aborts the log displays the local interface instead of the attempted socks proxy interface

### How

Mark that a proxy was used even if the connection was unsuccesful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line state flag change affecting only SOCKS proxy logging/metadata, not SMTP delivery logic.
> 
> **Overview**
> Ensures SOCKS connections are recorded as using a proxy as soon as the TCP connection to the SOCKS server succeeds.
> 
> `proxy_session` is now set to `TRUE` immediately after `smtp_sock_connect()` connects to the proxy (alongside `proxy_local_address`/`proxy_local_port`), so later handshake failures or aborted operations still log proxy context correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0df7539096d401f89562cb9ef30e414d8aced47b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->