### PR TITLE
MMA-10808. Fix bad memory allocation.

### DIFF
--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -933,8 +933,21 @@ router_name = transport_name = NULL;
 
 
 /*************************************************
-*        Generate local prt for logging          *
+*        Generate local part for logging         *
 *************************************************/
+
+static uschar *
+string_get_lpart_sub(const address_item * addr, uschar * s)
+{
+#ifdef SUPPORT_I18N
+if (testflag(addr, af_utf8_downcvt))
+  {
+  uschar * t = string_localpart_utf8_to_alabel(s, NULL);
+  return t ? t : s;	/* t is NULL on a failed conversion */
+  }
+#endif
+return s;
+}
 
 /* This function is a subroutine for use in string_log_address() below.
 
@@ -950,32 +963,13 @@ string_get_localpart(address_item * addr, gstring * yield)
 {
 uschar * s;
 
-s = addr->prefix;
-if (testflag(addr, af_include_affixes) && s)
-  {
-#ifdef SUPPORT_I18N
-  if (testflag(addr, af_utf8_downcvt))
-    s = string_localpart_utf8_to_alabel(s, NULL);
-#endif
-  yield = string_cat(yield, s);
-  }
+if (testflag(addr, af_include_affixes) && (s = addr->prefix))
+  yield = string_cat(yield, string_get_lpart_sub(addr, s));
 
-s = addr->local_part;
-#ifdef SUPPORT_I18N
-if (testflag(addr, af_utf8_downcvt))
-  s = string_localpart_utf8_to_alabel(s, NULL);
-#endif
-yield = string_cat(yield, s);
+yield = string_cat(yield, string_get_lpart_sub(addr, addr->local_part));
 
-s = addr->suffix;
-if (testflag(addr, af_include_affixes) && s)
-  {
-#ifdef SUPPORT_I18N
-  if (testflag(addr, af_utf8_downcvt))
-    s = string_localpart_utf8_to_alabel(s, NULL);
-#endif
-  yield = string_cat(yield, s);
-  }
+if (testflag(addr, af_include_affixes) && (s = addr->suffix))
+  yield = string_cat(yield, string_get_lpart_sub(addr, s));
 
 return yield;
 }

--- a/src/src/utf8.c
+++ b/src/src/utf8.c
@@ -133,7 +133,7 @@ return s;
 uschar *
 string_localpart_utf8_to_alabel(const uschar * utf8, uschar ** err)
 {
-size_t ucs4_len;
+size_t ucs4_len = 0;
 punycode_uint * p;
 size_t p_len;
 uschar * res;
@@ -142,6 +142,11 @@ int rc;
 if (!string_is_utf8(utf8)) return string_copy(utf8);
 
 p = (punycode_uint *) stringprep_utf8_to_ucs4(CCS utf8, -1, &ucs4_len);
+if (!p || !ucs4_len)
+  {
+  if (err) *err = US"l_u2a: bad UTF-8 input";
+  return NULL;
+  }
 p_len = ucs4_len*4;	/* this multiplier is pure guesswork */
 res = store_get(p_len+5, is_tainted(utf8));
 


### PR DESCRIPTION
### Why we need this

When we generate a bounce for a non-ascii sender exim tries to deliver it to the mx.
If the mx supports smtputf8 then delivery works fine.
If the mx does not support smtputf8 then exim tries to downconvert the address but that fails.
When this is done as part of exim -qf we end up with a bad memory allocation error

### Ticket

MMA-10808

### How we fix this.

This is already patched in 4.96 so we just pull the upstream patches.
