### PR TITLE
MMA-10799 - Apply Disable version in binary patch

### DIFF
--- a/src/scripts/exim_install
+++ b/src/scripts/exim_install
@@ -224,6 +224,8 @@ while [ $# -gt 0 ]; do
     version=exim-`$exim 2>/dev/null | \
       awk '/Exim version/ { OFS=""; print $3,"-",substr($4,2,length($4)-1) }'`${EXE}
 
+    version=exim
+
     if [ "${version}" = "exim-${EXE}" ]; then
       echo $com ""
       echo $com "*** Could not run $exim to find version number ***"
@@ -373,10 +375,8 @@ done
 
 
 
-# If there is no configuration file, install the default, modifying it to refer
-# to the configured system aliases file. If there is no setting for
-# SYSTEM_ALIASES_FILE, use the traditional /etc/aliases. If the file does not
-# exist, install a default (dummy) for that too.
+# Install default configuration file
+# This is a local Debian modification.
 
 # However, if CONFIGURE_FILE specifies a list of files, skip this code.
 
@@ -399,7 +399,7 @@ elif [ ! -f ${CONFIGURE_FILE} ]; then
   ${real} ${MKDIR} -p `${DIRNAME} ${CONFIGURE_FILE}`
 
   echo sed -e '\\'
-  echo "  \"/SYSTEM_ALIASES_FILE/ s'SYSTEM_ALIASES_FILE'${ACTUAL_SYSTEM_ALIASES_FILE}'\"" '\\'
+  echo "  \"/SYSTEM_ALIASES_FILE/ s'SYSTEM_ALIASES_FILE'/etc/aliases'\"" '\\'
   echo "  ../src/configure.default > \${CONFIGURE_FILE}"
 
   # I can't find a way of writing this using the ${real} feature because
@@ -408,7 +408,7 @@ elif [ ! -f ${CONFIGURE_FILE} ]; then
 
   if [ "$real" = "" ] ; then
     sed -e \
-      "/SYSTEM_ALIASES_FILE/ s'SYSTEM_ALIASES_FILE'${ACTUAL_SYSTEM_ALIASES_FILE}'" \
+      "/SYSTEM_ALIASES_FILE/ s'SYSTEM_ALIASES_FILE'/etc/aliases'" \
       ../src/configure.default > ${CONFIGURE_FILE}
   else
     true


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10799](https://n-able.atlassian.net/browse/MMA-10799)

### How we fix this.

Apply Disable version in binary [patch](https://github.com/SpamExperts/exim/commit/b5b69438587be03b207fd9c7218bb5d4e7391781).

[MMA-10799]: https://n-able.atlassian.net/browse/MMA-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ