### PR TITLE
MMA-10799 - Apply Extend header add buffer size patch

### DIFF
--- a/src/src/config.h.defaults
+++ b/src/src/config.h.defaults
@@ -83,7 +83,7 @@ Do not put spaces between # and the 'define'.
 #define HAVE_LOCAL_SCAN
 #define HAVE_SA_LEN
 #define HEADERS_CHARSET           "ISO-8859-1"
-#define HEADER_ADD_BUFFER_SIZE    (8192 * 4)
+#define HEADER_ADD_BUFFER_SIZE    (8192 * 10)
 #define HEADER_MAXSIZE            (1024*1024)
 
 #define INPUT_DIRECTORY_MODE       0750


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10799](https://n-able.atlassian.net/browse/MMA-10799)

### How we fix this.

Apply Extend header add buffer size [patch](https://github.com/SpamExperts/exim/commit/e85955d0150d2e4503650201a31e52ea9dc34c40).

[MMA-10799]: https://n-able.atlassian.net/browse/MMA-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ