### PR TITLE
MMA-10799 - Apply Syntesized SPF in DMARC check patch

### DIFF
--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -418,24 +418,24 @@ if (!dmarc_abort && !sender_host_authenticated)
   /* Use the envelope sender domain for this part of DMARC */
 
   spf_sender_domain = expand_string(US"$sender_address_domain");
+  /* No spf domain means null envelope sender so generate a domain name
+   * from the sender_helo_name  */
+  if (!*spf_sender_domain)
+    {
+    spf_sender_domain = sender_helo_name;
+    log_write(0, LOG_MAIN, "DMARC using synthesized SPF sender domain = %s\n",
+              spf_sender_domain);
+    DEBUG(D_receive)
+       debug_printf("DMARC using synthesized SPF sender domain = %s\n",
+       spf_sender_domain);
+    }
+
   if (!spf_response)
     {
-    /* No spf data means null envelope sender so generate a domain name
-    from the sender_helo_name  */
-
-    if (!spf_sender_domain)
-      {
-      spf_sender_domain = sender_helo_name;
-      log_write(0, LOG_MAIN, "DMARC using synthesized SPF sender domain = %s\n",
-			     spf_sender_domain);
-      DEBUG(D_receive)
-	debug_printf_indent("DMARC using synthesized SPF sender domain = %s\n",
-	  spf_sender_domain);
-      }
-    dmarc_spf_result = DMARC_POLICY_SPF_OUTCOME_NONE;
-    dmarc_spf_ares_result = ARES_RESULT_UNKNOWN;
-    origin = DMARC_POLICY_SPF_ORIGIN_HELO;
-    spf_human_readable = US"";
+      dmarc_spf_result = DMARC_POLICY_SPF_OUTCOME_NONE;
+      dmarc_spf_ares_result = ARES_RESULT_UNKNOWN;
+      origin = DMARC_POLICY_SPF_ORIGIN_HELO;
+      spf_human_readable = US"";
     }
   else
     {


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10799](https://n-able.atlassian.net/browse/MMA-10799)

### How we fix this.

Apply Syntesized SPF in DMARC check [patch](https://github.com/SpamExperts/exim/commit/7009ae3e7e053af3dbe26bead87d0381028c9bea).

[MMA-10799]: https://n-able.atlassian.net/browse/MMA-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ