### PR TITLE
MMA-10799 - Apply Fix segfault in print_dsn_diagnostic_code patch

### DIFF
--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -5438,6 +5438,9 @@ Returns:       nothing
 static void
 print_dsn_diagnostic_code(const address_item *addr, FILE *f)
 {
+
+if (addr == NULL) return;
+
 uschar * s = testflag(addr, af_pass_message) ? addr->message : NULL;
 unsigned cnt;
 


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10799](https://n-able.atlassian.net/browse/MMA-10799)

### How we fix this.

Apply Fix segfault in `print_dsn_diagnostic_code` [patch](https://github.com/SpamExperts/exim/commit/0e21c6a261ccccb671a4069c9c00058345acbf44).

[MMA-10799]: https://n-able.atlassian.net/browse/MMA-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ