### PR TITLE
MMA-10799 - Apply fix handling temporary rejection at callout patch

### DIFF
--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -840,6 +840,7 @@ tls_retry_connection:
 	    goto no_conn;
 	  case FAIL:		/* rejected: the preferred result */
 	    new_domain_record.random_result = ccache_reject;
+    case DEFER:		/* 4xx response to random */
 	    sx->avoid_option = 0;
 
 	    /* Between each check, issue RSET, because some servers accept only
@@ -871,7 +872,6 @@ tls_retry_connection:
 	    sx->send_rset = TRUE;
 	    sx->completed_addr = FALSE;
 	    goto tls_retry_connection;
-	  case DEFER:		/* 4xx response to random */
 	    break;		/* Just to be clear. ccache_unknown, !done. */
 	  }
 


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10799](https://n-able.atlassian.net/browse/MMA-10799)

### How we fix this.

Apply fix handling temporary rejection at callout patch.
https://github.com/SpamExperts/exim/commit/6bc3d4e9dc26a178cd09592e818c836cf83183db
https://github.com/SpamExperts/exim/commit/346b5d6a560c06ca0d938d08ef476972bedd2f5b

[MMA-10799]: https://n-able.atlassian.net/browse/MMA-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ