### PR TITLE
MMA-10799 - Apply Not-Quit ACL connection lost after dot patch

### DIFF
--- a/src/src/receive.c
+++ b/src/src/receive.c
@@ -4328,7 +4328,7 @@ if (  smtp_input && sender_host_address && !f.sender_host_notsocket
     if (c != EOF) (receive_ungetc)(c);
     else
       {
-      smtp_notquit_exit(US"connection-lost", NULL, NULL);
+      smtp_notquit_exit(US"connection-lost-after-dot", NULL, NULL);
       smtp_reply = US"";    /* No attempt to send a response */
       smtp_yield = FALSE;   /* Nothing more on this connection */
 


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10799](https://n-able.atlassian.net/browse/MMA-10799)

### How we fix this.

Apply Not-Quit ACL connection lost after dot [patch](https://github.com/SpamExperts/exim/commit/f082bb8e1c1b8bd05680a16ea586d718eda14ef8).

[MMA-10799]: https://n-able.atlassian.net/browse/MMA-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ