### PR TITLE
MMA-10800 - Apply add events for temporary failures patch

### DIFF
--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -1684,7 +1684,7 @@ else if (result == DEFER || result == PANIC)
     /* Skip this event for errors of the type "retry time not reached" */
     if (addr->basic_errno >= ERRNO_RETRY_BASE)
     {
-      if (deliver_freeze)
+      if (f.deliver_freeze)
         msg_event_raise(US"msg:defer:delivery:frozen", addr);
       else
         msg_event_raise(US"msg:defer:delivery", addr);

--- a/src/src/deliver.c
+++ b/src/src/deliver.c
@@ -1680,6 +1680,16 @@ else if (result == DEFER || result == PANIC)
   log or the main log for SMTP defers. */
 
   if (!f.queue_2stage || addr->basic_errno != 0)
+#ifndef DISABLE_EVENT
+    /* Skip this event for errors of the type "retry time not reached" */
+    if (addr->basic_errno >= ERRNO_RETRY_BASE)
+    {
+      if (deliver_freeze)
+        msg_event_raise(US"msg:defer:delivery:frozen", addr);
+      else
+        msg_event_raise(US"msg:defer:delivery", addr);
+    }
+#endif
     deferral_log(addr, now, logflags, driver_name, driver_kind);
   }
 
@@ -6065,6 +6075,9 @@ wording. */
     {
     for (address_item * addr = handled_addr; addr; addr = addr->next)
       {
+#ifndef DISABLE_EVENT
+      msg_event_raise(US"msg:fail:delivery:bounced", addr);
+#endif
       address_done(addr, logtod);
       child_done(addr, logtod);
       }
@@ -8228,6 +8241,11 @@ while (addr_failed)
 
   DEBUG(D_deliver)
     debug_printf("processing failed address %s\n", addr_failed->address);
+
+#ifndef DISABLE_EVENT
+  for (addr = addr_failed; addr != NULL; addr = addr->next)
+    msg_event_raise(US"msg:fail:delivery:expired", addr);
+#endif
 
   /* There are only two ways an address in a bounce message can get here:
 


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10800](https://n-able.atlassian.net/browse/MMA-10800)

### How we fix this.

Apply add events for temporary failures [patch](https://github.com/SpamExperts/exim/commit/7786bcb2e83f841a3ec42406a419eeb32f01c19d).

[MMA-10800]: https://n-able.atlassian.net/browse/MMA-10800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ