### PR TITLE
MMA-10800 - Apply Extend auth ACLs patch

### DIFF
--- a/src/src/globals.c
+++ b/src/src/globals.c
@@ -445,6 +445,8 @@ uschar *acl_not_smtp_mime      = NULL;
 uschar *acl_not_smtp_start     = NULL;
 uschar *acl_removed_headers    = NULL;
 uschar *acl_smtp_auth          = NULL;
+uschar *acl_smtp_auth_accept   = NULL;
+uschar *acl_smtp_auth_fail     = NULL;
 uschar *acl_smtp_connect       = NULL;
 uschar *acl_smtp_data          = NULL;
 #ifndef DISABLE_PRDR

--- a/src/src/globals.h
+++ b/src/src/globals.h
@@ -319,6 +319,8 @@ extern uschar *acl_not_smtp_mime;      /* For MIME parts of ditto */
 extern uschar *acl_not_smtp_start;     /* ACL run at the beginning of a non-SMTP session */
 extern uschar *acl_removed_headers;    /* Headers deleted by an ACL */
 extern uschar *acl_smtp_auth;          /* ACL run for AUTH */
+extern uschar *acl_smtp_auth_accept;   /* ACL run for AUTH Success*/
+extern uschar *acl_smtp_auth_fail;     /* ACL run for AUTH Fail*/
 extern uschar *acl_smtp_connect;       /* ACL run on SMTP connection */
 extern uschar *acl_smtp_data;          /* ACL run after DATA received */
 #ifndef DISABLE_PRDR

--- a/src/src/readconf.c
+++ b/src/src/readconf.c
@@ -42,6 +42,8 @@ static optionlist optionlist_config[] = {
 #endif
   { "acl_not_smtp_start",       opt_stringptr,   {&acl_not_smtp_start} },
   { "acl_smtp_auth",            opt_stringptr,   {&acl_smtp_auth} },
+  { "acl_smtp_auth_accept",     opt_stringptr,   {&acl_smtp_auth_accept} },
+  { "acl_smtp_auth_fail",       opt_stringptr,   {&acl_smtp_auth_fail} },
   { "acl_smtp_connect",         opt_stringptr,   {&acl_smtp_connect} },
   { "acl_smtp_data",            opt_stringptr,   {&acl_smtp_data} },
 #ifndef DISABLE_PRDR

--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -3396,10 +3396,10 @@ smtp_respond(code, len, SR_FINAL, user_msg);
 
 
 static int
-smtp_in_auth(auth_instance *au, uschar ** smtp_resp, uschar ** errmsg)
+smtp_in_auth(auth_instance *au, uschar ** smtp_resp, uschar ** errmsg, uschar *user_msg, uschar *log_msg)
 {
 const uschar *set_id = NULL;
-int rc;
+int rc, acl_rc, i;
 
 /* Set up globals for error messages */
 
@@ -3437,6 +3437,18 @@ printing characters. */
 
 if (set_id) set_id = string_printing(set_id);
 
+if (set_id != NULL) strcpy(smtp_cmd_argument, set_id);
+/* Check the ACL */
+if (acl_smtp_auth != NULL)
+ {
+  acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth, &user_msg, &log_msg);
+  if (acl_rc != OK)
+  {
+    smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+    return acl_rc;
+  }
+ }
+
 /* For the non-OK cases, set up additional logging data if set_id
 is not empty. */
 
@@ -3451,6 +3463,16 @@ switch(rc)
   case OK:
     if (!au->set_id || set_id)    /* Complete success */
       {
+        if (acl_smtp_auth_accept != NULL)
+          {
+            acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_accept, &user_msg, &log_msg);
+            if (acl_rc != OK)
+            {
+              smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+              rc = acl_rc;
+              break;
+            }
+          }
       if (set_id) authenticated_id = string_copy_perm(set_id, TRUE);
       sender_host_authenticated = au->name;
       sender_host_auth_pubname  = au->public_name;
@@ -3492,6 +3514,15 @@ switch(rc)
     break;
 
   case FAIL:
+    if (acl_smtp_auth_fail != NULL)
+      {
+        acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_fail, &user_msg, &log_msg);
+        if (acl_rc != OK)
+        {
+          smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+          break;
+        }
+      }
     if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
     *smtp_resp = US"535 Incorrect authentication data";
     *errmsg = string_sprintf("535 Incorrect authentication data%s", set_id);
@@ -3755,7 +3786,7 @@ while (done <= 0)
 	  {
 	  smtp_cmd_data = NULL;
 
-	  if (smtp_in_auth(au, &s, &ss) == OK)
+	  if (smtp_in_auth(au, &s, &ss, &user_msg, &log_msg) == OK)
 	    { DEBUG(D_auth) debug_printf("tls auth succeeded\n"); }
 	  else
 	    {
@@ -3821,19 +3852,6 @@ while (done <= 0)
 	  US"not permitted in mail transaction");
 	break;
 	}
-
-      /* Check the ACL */
-
-      GET_OPTION("acl_smtp_auth");
-      if (  acl_smtp_auth
-	 && (rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth,
-		    &user_msg, &log_msg)) != OK
-	 )
-	{
-	done = smtp_handle_acl_fail(ACL_WHERE_AUTH, rc, user_msg, log_msg);
-	break;
-	}
-
       /* Find the name of the requested authentication mechanism. */
 
       s = smtp_cmd_data;
@@ -3869,7 +3887,7 @@ while (done <= 0)
 
 	if (au)
 	  {
-	  int rc = smtp_in_auth(au, &smtp_resp, &errmsg);
+	  int rc = smtp_in_auth(au, &smtp_resp, &errmsg, &user_msg, &log_msg);
 
 	  smtp_printf("%s\r\n", SP_NO_MORE, smtp_resp);
 	  if (rc != OK)


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10800](https://n-able.atlassian.net/browse/MMA-10800)

### How we fix this.

Apply Extend auth ACLs [patch](https://github.com/SpamExperts/exim/commit/23614f8d4c0fdea0ec3d293c0c9e78dba5b56837).


[MMA-10800]: https://n-able.atlassian.net/browse/MMA-10800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ