### PR TITLE
MMA-10800 - Use opendmarc query function instead of custom code

### DIFF
--- a/src/src/dmarc.c
+++ b/src/src/dmarc.c
@@ -184,6 +184,7 @@ if (  dmarc_policy == DMARC_POLICY_REJECT     && action == DMARC_RESULT_REJECT
    || dmarc_policy == DMARC_POLICY_QUARANTINE && action == DMARC_RESULT_QUARANTINE
    || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_REJECT
    || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_QUARANTINE
+   || dmarc_policy == DMARC_POLICY_NONE       && action == DMARC_RESULT_ACCEPT
    )
   if (ruf)
     {
@@ -517,14 +518,8 @@ The EDITME provides a DMARC_API variable */
 #endif
     }
 
-  /* Look up DMARC policy record in DNS.  We do this explicitly, rather than
-  letting the dmarc library do it with opendmarc_policy_query_dmarc(), so that
-  our dns access path is used for debug tracing and for the testsuite
-  diversion. */
+  libdm_status = opendmarc_policy_query_dmarc(dmarc_pctx, US"");
 
-  libdm_status = (rr = dmarc_dns_lookup(header_from_sender))
-    ? opendmarc_policy_store_dmarc(dmarc_pctx, rr, header_from_sender, NULL)
-    : DMARC_DNS_ERROR_NO_RECORD;
   switch (libdm_status)
     {
     case DMARC_DNS_ERROR_NXDOMAIN:


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10800](https://n-able.atlassian.net/browse/MMA-10800)

### How we fix this.

Use opendmarc query function instead of custom code.
https://github.com/SpamExperts/exim/pull/38

[MMA-10800]: https://n-able.atlassian.net/browse/MMA-10800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ