### PR TITLE
MMA-10800 - Apply clear callout cache patch

### DIFF
--- a/src/src/verify.c
+++ b/src/src/verify.c
@@ -517,6 +517,9 @@ new_domain_record.result = ccache_unknown;
 new_domain_record.postmaster_result = ccache_unknown;
 new_domain_record.random_result = ccache_unknown;
 
+recipient_verify_message = "";
+sender_verify_message = "";
+
 memset(&new_address_record, 0, sizeof(new_address_record));
 
 /* For a recipient callout, the key used for the address cache record must
@@ -634,15 +637,6 @@ coding means skipping this whole loop and doing the append separately.  */
      && !pm_mailfrom
      )
     done = cutthrough_multi(addr, host_list, tf, &yield);
-
-    if (options & vopt_is_recipient)
-    {
-      recipient_verify_message = addr->user_message;
-    }
-    else
-    {
-      sender_verify_message = addr->user_message;
-    }
 
   /* If we did not use a cached connection, make connections to the hosts
   and do real callouts. The list of hosts is passed in as an argument. */
@@ -1079,7 +1073,16 @@ no_conn:
 	addr->user_message = options & vopt_is_recipient
 	  ? string_sprintf("Callout verification failed:\n%s", sx->buffer)
 	  : string_sprintf("Called:   %s\nSent:     %s\nResponse: %s",
-	    host->address, big_buffer, sx->buffer);
+	    
+      
+  if (options & vopt_is_recipient)
+  {
+    recipient_verify_message = string_sprintf("%s", sx->buffer);
+  }
+  else
+  {
+    sender_verify_message = string_sprintf("%s", sx->buffer);
+  }
 
 	/* Hard rejection ends the process */
 


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10800](https://n-able.atlassian.net/browse/MMA-10800)

### How we fix this.

Apply clear callout cache patch.
https://github.com/SpamExperts/exim/commit/6f6652e52c012c287538a61431713fdf643509d0
https://github.com/SpamExperts/exim/pull/37

[MMA-10800]: https://n-able.atlassian.net/browse/MMA-10800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ