### PR TITLE
MMA-10921 - Apply patches for CVE-2026-40685 and CVE-2026-40686

### DIFF
--- a/src/src/expand.c
+++ b/src/src/expand.c
@@ -977,7 +977,7 @@ static int utf8_table2[] = { 0xff, 0x1f, 0x0f, 0x07, 0x03, 0x01};
     int a = utf8_table1[c & 0x3f];  /* Number of additional bytes */ \
     int s = 6*a; \
     c = (c & utf8_table2[a]) << s; \
-    while (a-- > 0) \
+    while (a-- > 0 && *ptr) \
       { \
       s -= 6; \
       c |= (*ptr++ & 0x3f) << s; \
@@ -2383,7 +2383,7 @@ if (Uskip_whitespace(&p) == *wrap)
   wrap++;
   while (*p)
     {
-    if (*p == '\\') p++;
+    if (*p == '\\' && *(p+1)) p++;
     else if (!quotesmode && *p == wrap[-1]) depth++;
     else if (*p == *wrap)
       if (depth == 0)
@@ -7918,7 +7918,7 @@ NOT_ITEM: ;
 		  /* A UTF-16 surrogate (which should be one of a pair that
 		  encode a Unicode codepoint that is outside the Basic
 		  Multilingual Plane).  Error, not UTF8.
-		  RFC2279.2 is slightly unclear on this, but 
+		  RFC2279.2 is slightly unclear on this, but
 		  https://unicodebook.readthedocs.io/issues.html#strict-utf8-decoder
 		  says "Surrogates characters are also invalid in UTF-8:
 		  characters in U+D800—U+DFFF have to be rejected." */


### PR DESCRIPTION
### Why we need this

We need to publish a new version of Exim, which patches these CVEs.

### How we fix it

We apply both patches in a single PR, so it's easier to keep track of this change:
https://code.exim.org/exim/exim/commit/9fdc057e71b87c87a0d3d2288b2810a0efaaba57
https://code.exim.org/exim/exim/commit/f2570bde16fb4d4a1242ff363a4c4eecf6372efc