### PR TITLE
MMA-10800 - Set proxy session true earlier even on cancelled operations.

### DIFF
--- a/src/src/transports/smtp_socks.c
+++ b/src/src/transports/smtp_socks.c
@@ -301,6 +301,7 @@ for(;;)
     {
     proxy_local_address = string_copy(proxy.address);
     proxy_local_port = sob->port;
+    proxy_session = TRUE;
     break;
     }
 


### PR DESCRIPTION
### Why we need this

Apply missing patch to `Exim 4.98`.

### Ticket

[MMA-10800](https://n-able.atlassian.net/browse/MMA-10800)

### How we fix this.

Set proxy session true earlier even on cancelled operations.
https://github.com/SpamExperts/exim/pull/53

[MMA-10800]: https://n-able.atlassian.net/browse/MMA-10800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ