### PR TITLE
MMA-10674. Enable EXPERIMENTAL_ARC support in EDITME

### DIFF
--- a/src/src/EDITME
+++ b/src/src/EDITME
@@ -623,7 +623,7 @@ LDFLAGS += -lopendmarc
 
 # Uncomment the following line to add ARC (Authenticated Received Chain)
 # support.  You must have SPF and DKIM support enabled also.
-# EXPERIMENTAL_ARC=yes
+EXPERIMENTAL_ARC=yes
 
 # Uncomment the following lines to add Brightmail AntiSpam support. You need
 # to have the Brightmail client SDK installed. Please check the experimental


### PR DESCRIPTION
We enabled this on 4.94 but we need it on 4.98 as well since exim doesn't find the variable without it.
```
2026-06-08 12:32:01 [62862] Exim configuration error in line 2697 of /var/lib/exim4/incoming-config.autogenerated:
  option "arc_sign" unknown
  ```
  # Ticket
  MMA-10674