### PR TITLE
MMA-11008. fix extended auth patch

### DIFF
--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -3445,6 +3445,9 @@ if (acl_smtp_auth != NULL)
   if (acl_rc != OK)
   {
     smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+    if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
+    *smtp_resp = US"535 Incorrect authentication data";
+    *errmsg = string_sprintf("535 Incorrect authentication data%s", set_id);
     return acl_rc;
   }
  }
@@ -3463,16 +3466,6 @@ switch(rc)
   case OK:
     if (!au->set_id || set_id)    /* Complete success */
       {
-        if (acl_smtp_auth_accept != NULL)
-          {
-            acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_accept, &user_msg, &log_msg);
-            if (acl_rc != OK)
-            {
-              smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
-              rc = acl_rc;
-              break;
-            }
-          }
       if (set_id) authenticated_id = string_copy_perm(set_id, TRUE);
       sender_host_authenticated = au->name;
       sender_host_auth_pubname  = au->public_name;
@@ -3484,6 +3477,17 @@ switch(rc)
 	  [pextend + pauthed + (tls_in.active.sock >= 0 ? pcrpted:0)];
       *smtp_resp = *errmsg = US"235 Authentication succeeded";
       authenticated_by = au;
+
+        if (acl_smtp_auth_accept != NULL)
+          {
+            acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_accept, &user_msg, &log_msg);
+            if (acl_rc != OK)
+            {
+              smtp_handle_acl_fail(ACL_WHERE_AUTH, acl_rc, user_msg, log_msg);
+              rc = acl_rc;
+              break;
+            }
+          }
       break;
       }
 
@@ -3514,6 +3518,10 @@ switch(rc)
     break;
 
   case FAIL:
+    if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
+    *smtp_resp = US"535 Incorrect authentication data";
+    *errmsg = string_sprintf("535 Incorrect authentication data%s", set_id);
+
     if (acl_smtp_auth_fail != NULL)
       {
         acl_rc = acl_check(ACL_WHERE_AUTH, NULL, acl_smtp_auth_fail, &user_msg, &log_msg);
@@ -3523,9 +3531,6 @@ switch(rc)
           break;
         }
       }
-    if (set_id) authenticated_fail_id = string_copy_perm(set_id, TRUE);
-    *smtp_resp = US"535 Incorrect authentication data";
-    *errmsg = string_sprintf("535 Incorrect authentication data%s", set_id);
     break;
 
   default:


### PR DESCRIPTION
## Why we need this

On rejected authentication attempts we don't always fill out the smtp_resp/errmsg before exiting causing segfaults.

## Ticket
MMA-11008

## How we fix this.
Reapply the changes from the previous patches #46 