### PR TITLE
MMA-11056. Fix compile warnings for improper pointer usage

### DIFF
--- a/src/src/smtp_in.c
+++ b/src/src/smtp_in.c
@@ -3791,7 +3791,7 @@ while (done <= 0)
 	  {
 	  smtp_cmd_data = NULL;
 
-	  if (smtp_in_auth(au, &s, &ss, &user_msg, &log_msg) == OK)
+	  if (smtp_in_auth(au, &s, &ss, user_msg, log_msg) == OK)
 	    { DEBUG(D_auth) debug_printf("tls auth succeeded\n"); }
 	  else
 	    {
@@ -3892,7 +3892,7 @@ while (done <= 0)
 
 	if (au)
 	  {
-	  int rc = smtp_in_auth(au, &smtp_resp, &errmsg, &user_msg, &log_msg);
+	  int rc = smtp_in_auth(au, &smtp_resp, &errmsg, user_msg, log_msg);
 
 	  smtp_printf("%s\r\n", SP_NO_MORE, smtp_resp);
 	  if (rc != OK)


### PR DESCRIPTION
We see this in our exim-build pipeline and it comes from one of our patches.
```
smtp_in.c: In function ‘smtp_setup_msg’:
smtp_in.c:3890:58: warning: passing argument 4 of ‘smtp_in_auth’ from incompatible pointer type [-Wincompatible-pointer-types]
 3890 |           int rc = smtp_in_auth(au, &smtp_resp, &errmsg, &user_msg, &log_msg);
      |                                                          ^~~~~~~~~
      |                                                          |
      |                                                          uschar ** {aka unsigned char **}
smtp_in.c:3399:80: note: expected ‘uschar *’ {aka ‘unsigned char *’} but argument is of type ‘uschar **’ {aka ‘unsigned char **’}
 3399 | smtp_in_auth(auth_instance *au, uschar ** smtp_resp, uschar ** errmsg, uschar *user_msg, uschar *log_msg)
      |                                                                        ~~~~~~~~^~~~~~~~
smtp_in.c:3890:69: warning: passing argument 5 of ‘smtp_in_auth’ from incompatible pointer type [-Wincompatible-pointer-types]
 3890 |           int rc = smtp_in_auth(au, &smtp_resp, &errmsg, &user_msg, &log_msg);
      |                                                                     ^~~~~~~~
      |                                                                     |
      |                                                                     uschar ** {aka unsigned char **}
smtp_in.c:3399:98: note: expected ‘uschar *’ {aka ‘unsigned char *’} but argument is of type ‘uschar **’ {aka ‘unsigned char **’}
 3399 | smtp_in_auth(auth_instance *au, uschar ** smtp_resp, uschar ** errmsg, uschar *user_msg, uschar *log_msg)
      |          
 ```
 
 MMA-11056
 
 ### How we fix it
 Properly pass the logger to the smtp_in_auth function
 
Patch where we extended this function and called it with the new params https://github.com/SpamExperts/exim/pull/69/changes
